### PR TITLE
Renamed effectuation date to creation date

### DIFF
--- a/source/Contracts/v1/Document.proto
+++ b/source/Contracts/v1/Document.proto
@@ -21,7 +21,7 @@ option csharp_namespace = "Energinet.DataHub.PostOffice.Contracts";
 
 message Document {
   string type = 1;
-  google.protobuf.Timestamp effectuationDate = 2;
+  google.protobuf.Timestamp creationDate = 2;
   string recipient = 3;
   string content = 4;
   string version = 5;

--- a/source/Energinet.DataHub.PostOffice.Domain/Document.cs
+++ b/source/Energinet.DataHub.PostOffice.Domain/Document.cs
@@ -22,7 +22,7 @@ namespace Energinet.DataHub.PostOffice.Domain
 
         public string? Type { get; set; }
 
-        public Instant? EffectuationDate { get; set; }
+        public Instant? CreationDate { get; set; }
 
         public object? Content { get; set; }
 

--- a/source/Energinet.DataHub.PostOffice.Inbound/Parsing/DocumentMustHaveEffectuationDate.cs
+++ b/source/Energinet.DataHub.PostOffice.Inbound/Parsing/DocumentMustHaveEffectuationDate.cs
@@ -19,7 +19,7 @@ using GreenEnergyHub.Messaging.Validation;
 
 namespace Energinet.DataHub.PostOffice.Inbound.Parsing
 {
-    public class DocumentMustHaveEffectuationDate : PropertyRule<Timestamp>
+    public class DocumentMustHaveCreationDate : PropertyRule<Timestamp>
     {
         protected override string Code => "Json Serializable Content";
 

--- a/source/Energinet.DataHub.PostOffice.Inbound/Parsing/DocumentRules.cs
+++ b/source/Energinet.DataHub.PostOffice.Inbound/Parsing/DocumentRules.cs
@@ -24,7 +24,7 @@ namespace Energinet.DataHub.PostOffice.Inbound.Parsing
             RuleFor(document => document.Version).PropertyRule<DocumentCannotHaveEmptyValue>();
             RuleFor(document => document.Recipient).PropertyRule<DocumentCannotHaveEmptyValue>();
             RuleFor(document => document.Content).PropertyRule<DocumentMustHaveJsonSerializableContent>();
-            RuleFor(document => document.EffectuationDate).PropertyRule<DocumentMustHaveEffectuationDate>();
+            RuleFor(document => document.CreationDate).PropertyRule<DocumentMustHaveCreationDate>();
         }
     }
 }

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/CosmosDocument.cs
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/CosmosDocument.cs
@@ -33,8 +33,8 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
         [JsonProperty(PropertyName = "recipient")]
         public string Recipient { get; set; }
 
-        [JsonProperty(PropertyName = "effectuationDate")]
-        public System.DateTimeOffset EffectuationDate { get; set; }
+        [JsonProperty(PropertyName = "creationDate")]
+        public System.DateTimeOffset CreationDate { get; set; }
 
         [JsonProperty(PropertyName = "content")]
         public object Content { get; set; }

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/CosmosDocumentMapper.cs
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/CosmosDocumentMapper.cs
@@ -31,7 +31,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
                 Version = obj.Version,
 
                 // TODO: fix epoch nullable hack
-                EffectuationDate = obj.EffectuationDate?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch,
+                CreationDate = obj.CreationDate?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch,
             };
         }
 
@@ -42,7 +42,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
             return new Domain.Document
             {
                 Content = obj.Content,
-                EffectuationDate = obj.EffectuationDate.ToInstant(),
+                CreationDate = obj.CreationDate.ToInstant(),
                 Recipient = obj.Recipient,
                 Type = obj.Type,
                 Bundle = obj.Bundle,

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/CosmosDocumentStore.cs
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/CosmosDocumentStore.cs
@@ -90,7 +90,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
                 SELECT TOP @pageSize *
                 FROM Documents d
                 WHERE d.recipient = @recipient
-                ORDER BY d.effectuationDate";
+                ORDER BY d.creationDate";
 
             var container = GetContainer(documentQuery.ContainerName);
 
@@ -148,7 +148,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
 
         private static async Task<IList<CosmosDocument>> CreateBundleAsync(Container container, DocumentQuery documentQuery)
         {
-            var typeQueryDefinition = new QueryDefinition(@"SELECT top 1 * FROM Documents d WHERE d.recipient = @recipient ORDER BY d.effectuationDate")
+            var typeQueryDefinition = new QueryDefinition(@"SELECT top 1 * FROM Documents d WHERE d.recipient = @recipient ORDER BY d.creationDate")
                 .WithParameter("@recipient", documentQuery.Recipient);
             var typeQuery = container.GetItemQueryIterator<CosmosDocument>(typeQueryDefinition);
 
@@ -166,7 +166,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
                 return new List<CosmosDocument>();
             }
 
-            var queryDefinition = new QueryDefinition(@"SELECT top @pageSize * FROM Documents d WHERE d.recipient = @recipient AND d.type = @type ORDER BY d.effectuationDate")
+            var queryDefinition = new QueryDefinition(@"SELECT top @pageSize * FROM Documents d WHERE d.recipient = @recipient AND d.type = @type ORDER BY d.creationDate")
                 .WithParameter("@recipient", documentQuery.Recipient)
                 .WithParameter("@pageSize", documentQuery.PageSize)
                 .WithParameter("@type", type);

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/DocumentMapper.cs
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/DocumentMapper.cs
@@ -30,7 +30,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure
                 Content = Newtonsoft.Json.JsonConvert.DeserializeObject<dynamic>(obj.Content),
                 Type = obj.Type,
                 Recipient = obj.Recipient,
-                EffectuationDate = obj.EffectuationDate.ToInstant(),
+                CreationDate = obj.CreationDate.ToInstant(),
                 Version = obj.Version,
             };
 

--- a/source/Energinet.DataHub.PostOffice.Tests/DocumentMapperTests.cs
+++ b/source/Energinet.DataHub.PostOffice.Tests/DocumentMapperTests.cs
@@ -33,13 +33,13 @@ namespace Energinet.DataHub.PostOffice.Tests
         [Fact]
         public void DocumentShouldBeMapped()
         {
-            var effectuationDate = _fixture.Create<Timestamp>();
+            var creationDate = _fixture.Create<Timestamp>();
             var type = _fixture.Create<string>();
             var recipient = _fixture.Create<string>();
             var content = "{\"document\": \"Important message.\"}";
             var document = new Document
             {
-                EffectuationDate = effectuationDate,
+                CreationDate = creationDate,
                 Type = type,
                 Recipient = recipient,
                 Content = content,
@@ -50,7 +50,7 @@ namespace Energinet.DataHub.PostOffice.Tests
             actual.Should().NotBeNull();
             actual.Type.Should().Be(type);
             actual.Recipient.Should().Be(recipient);
-            actual.EffectuationDate?.ToDateTimeOffset().Should().Be(effectuationDate.ToDateTimeOffset());
+            actual.CreationDate?.ToDateTimeOffset().Should().Be(creationDate.ToDateTimeOffset());
         }
     }
 }

--- a/source/Energinet.DataHub.PostOffice.Tests/IntegrationTests.cs
+++ b/source/Energinet.DataHub.PostOffice.Tests/IntegrationTests.cs
@@ -136,7 +136,7 @@ namespace Energinet.DataHub.PostOffice.Tests
             {
                 documents.Add(new Document
                 {
-                    EffectuationDate = Timestamp.FromDateTimeOffset(DateTimeOffset.Now.AddMinutes(index)),
+                    CreationDate = Timestamp.FromDateTimeOffset(DateTimeOffset.Now.AddMinutes(index)),
                     Recipient = recipient,
                     Type = type,
                     Content = "{\"document\":\"" + index + "\"}",

--- a/source/Energinet.DataHub.PostOffice.Tests/ManualTests.cs
+++ b/source/Energinet.DataHub.PostOffice.Tests/ManualTests.cs
@@ -51,7 +51,7 @@ namespace Energinet.DataHub.PostOffice.Tests
         {
             var document = new Contracts.Document
             {
-                EffectuationDate = Timestamp.FromDateTimeOffset(_faker.Date.Soon()),
+                CreationDate = Timestamp.FromDateTimeOffset(_faker.Date.Soon()),
                 Recipient = _faker.PickRandom("greenenergy", "vELkommen"),
                 Type = _faker.PickRandom("changeofsupplier"), //, "movein", "moveout"),
                 Content = "{\"document\":\"" + _faker.Rant.Review() + "\"}",

--- a/source/Energinet.DataHub.PostOffice.Tests/ValidationTests.cs
+++ b/source/Energinet.DataHub.PostOffice.Tests/ValidationTests.cs
@@ -46,14 +46,14 @@ namespace Energinet.DataHub.PostOffice.Tests
         [Fact]
         public async Task A_valid_document_should_validate()
         {
-            var effectuationDate = _fixture.Create<Timestamp>();
+            var creationDate = _fixture.Create<Timestamp>();
             var type = _fixture.Create<string>();
             var recipient = _fixture.Create<string>();
             var version = _fixture.Create<string>();
             var content = "{\"document\": \"Important message.\"}";
             var document = new Document
             {
-                EffectuationDate = effectuationDate,
+                CreationDate = creationDate,
                 Type = type,
                 Recipient = recipient,
                 Content = content,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/green-energy-hub) before we can accept your contribution. --->

## Description

Effectuation date wasn't the proper name for this field.  The date in this field indicates when the message was created not when it should go into effect.
