### PR TITLE
Allow client assertions via action

### DIFF
--- a/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj
+++ b/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.IntegrationTesting</PackageId>
-    <PackageVersion>1.1.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>1.1.2$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.IntegrationTesting library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/MessageHubSimulation.cs
+++ b/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/MessageHubSimulation.cs
@@ -89,6 +89,18 @@ namespace Energinet.DataHub.MessageHub.IntegrationTesting
         /// <param name="correlationIds">The list of correlation ids to wait for.</param>
         public async Task WaitForNotificationsInDataAvailableQueueAsync(params string[] correlationIds)
         {
+            await WaitForNotificationsInDataAvailableQueueWithAssertionAsync(correlationIds).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Waits for the specified correlation ids to arrive on the dataavailable queue
+        /// and adds their notifications to the current simulation.
+        /// Can throw a TimeoutException or TaskCanceledException.
+        /// </summary>
+        /// <param name="correlationIds">The list of correlation ids to wait for.</param>
+        /// <param name="action">Action for dto, to allow assertions</param>
+        public async Task WaitForNotificationsInDataAvailableQueueWithAssertionAsync(string[] correlationIds, Action<DataAvailableNotificationDto>? action = null)
+        {
             using var cancellationTokenSource = new CancellationTokenSource(_waitTimeout);
             var cancellationToken = cancellationTokenSource.Token;
 
@@ -108,6 +120,7 @@ namespace Energinet.DataHub.MessageHub.IntegrationTesting
                     if (correlationObj is string correlationId && expectedIds.Remove(correlationId))
                     {
                         var dataAvailableNotificationDto = _dataAvailableNotificationParser.Parse(message.Body.ToArray());
+                        action?.Invoke(dataAvailableNotificationDto);
                         _notifications.Add(dataAvailableNotificationDto);
                     }
                 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-post-office) before we can accept your contribution. --->

## Description

This PR adds functionality to the Simulation package.
Clients can assert on specific messages via Action in `WaitForNotificationsInDataAvailableQueueWithAssertionAsync`

## References
