### PR TITLE
Upgrade to .NET 6 and Functions v4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -269,7 +269,10 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
-# Analyzers/StyleCop rules
+###############################
+# .NET Analyzers              #
+###############################
+
 dotnet_diagnostic.CA1303.severity = suggestion
 dotnet_diagnostic.CA1715.severity = error
 dotnet_diagnostic.CA1001.severity = warning
@@ -292,6 +295,7 @@ dotnet_diagnostic.CA1410.severity = warning
 dotnet_diagnostic.CA1415.severity = warning
 dotnet_diagnostic.CA1812.severity = suggestion
 dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1848.severity = suggestion
 dotnet_diagnostic.CA1900.severity = warning
 dotnet_diagnostic.CA1901.severity = warning
 dotnet_diagnostic.CA2002.severity = warning
@@ -337,6 +341,13 @@ dotnet_diagnostic.CA2240.severity = warning
 dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
 dotnet_diagnostic.CS1591.severity = none
+
+###############################
+# StyleCop Analyzers          #
+###############################
+
+# See rules here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1000.severity = error
 dotnet_diagnostic.SA1001.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -520,3 +520,12 @@ dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
 
 dotnet_code_quality.CA1062.null_check_validation_methods = ThrowIfNull|ThrowIfNullOrWhiteSpace
+
+###############################
+# Code Style rules (IDE)      #
+###############################
+
+# See rules here: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = warning

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,12 +33,12 @@ jobs:
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
-  
+
   update_coverage_report:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.PostOffice.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_COSMOS_DB_EMULATOR: true
       USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.0.0
 
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.PostOffice.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_COSMOS_DB_EMULATOR: true
       USE_AZURE_FUNCTIONS_TOOLS: true
     secrets:
@@ -40,7 +40,7 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.PostOffice.Libraries.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -56,26 +56,26 @@ jobs:
 
   market_operator_ci:
     needs: [ci_base, dotnet_solution_ci, package_ci, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.PostOffice.EntryPoint.MarketOperator/Energinet.DataHub.PostOffice.EntryPoint.MarketOperator.csproj'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: marketoperator
 
   subdomain_ci:
     needs: [ci_base, dotnet_solution_ci, package_ci, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.PostOffice.EntryPoint.SubDomain/Energinet.DataHub.PostOffice.EntryPoint.SubDomain.csproj'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: subdomain
 
   operations_ci:
     needs: [ci_base, dotnet_solution_ci, package_ci, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.PostOffice.EntryPoint.Operations/Energinet.DataHub.PostOffice.EntryPoint.Operations.csproj'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: operations
 
   create_prerelease:
@@ -84,4 +84,4 @@ jobs:
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-post-office
     secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/publish-messagehub-client-simpleinjector.yml
+++ b/.github/workflows/publish-messagehub-client-simpleinjector.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/bin/Release/*.nupkg'
 

--- a/.github/workflows/publish-messagehub-client.yml
+++ b/.github/workflows/publish-messagehub-client.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/bin/Release/*.nupkg'
 

--- a/.github/workflows/publish-messagehub-core.yml
+++ b/.github/workflows/publish-messagehub-core.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/bin/Release/*.nupkg'
 

--- a/.github/workflows/publish-messagehub-integrationtesting.yml
+++ b/.github/workflows/publish-messagehub-integrationtesting.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/bin/Release/*.nupkg'
 

--- a/.github/workflows/publish-messagehub-model.yml
+++ b/.github/workflows/publish-messagehub-model.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/bin/Release/*.nupkg'
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/build/infrastructure/main/func-marketoperator.tf
+++ b/build/infrastructure/main/func-marketoperator.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_marketoperator" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "marketoperator"
   project_name                              = var.domain_name_short
@@ -21,7 +21,8 @@ module "func_marketoperator" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values
@@ -46,6 +47,6 @@ module "func_marketoperator" {
     # feature flags
     FEATURE_SENDMESSAGETYPEHEADER             = local.feature_send_messagetype_header
   }
-  
+
   tags                                      = azurerm_resource_group.this.tags
 }

--- a/build/infrastructure/main/func-operations.tf
+++ b/build/infrastructure/main/func-operations.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_operations" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "operations"
   project_name                              = var.domain_name_short
@@ -21,7 +21,8 @@ module "func_operations" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values
@@ -44,6 +45,6 @@ module "func_operations" {
     BACKEND_SERVICE_APP_ID                    = data.azurerm_key_vault_secret.backend_service_app_id.value
     SQL_ACTOR_DB_CONNECTION_STRING            = local.sql_actor_db_connection_string
   }
-  
+
   tags                                      = azurerm_resource_group.this.tags
 }

--- a/build/infrastructure/main/func-subdomain.tf
+++ b/build/infrastructure/main/func-subdomain.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_subdomain" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "subdomain"
   project_name                              = var.domain_name_short
@@ -21,7 +21,8 @@ module "func_subdomain" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values
@@ -43,6 +44,6 @@ module "func_subdomain" {
     RequestResponseLogConnectionString        = data.azurerm_key_vault_secret.st_market_operator_logs_primary_connection_string.value
     RequestResponseLogContainerName           = data.azurerm_key_vault_secret.st_market_operator_logs_container_name.value
   }
-  
+
   tags                                      = azurerm_resource_group.this.tags
 }

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -31,7 +31,7 @@ data "azurerm_key_vault_secret" "st_market_operator_response_postofficereply_con
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
 
-data "azurerm_key_vault_secret" "appi_instrumentation_key" {
+data "azurerm_key_vault_secret" "appi_shared_instrumentation_key" {
   name         = "appi-shared-instrumentation-key"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
@@ -88,5 +88,10 @@ data "azurerm_key_vault_secret" "mssql_data_admin_password" {
 
 data "azurerm_key_vault_secret" "plan_shared_id" {
   name         = "plan-shared-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}
+
+data "azurerm_key_vault_secret" "log_shared_id" {
+  name         = "log-shared-id"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }

--- a/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MessageHub.SimpleInjector Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade.
+
 ## Version 1.0.0
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{CC5EB98C-635A-465E-85F7-7925BB365AF5}</ProjectGuid>

--- a/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
@@ -66,11 +66,11 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SimpleInjector" Version="5.3.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
 
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
@@ -66,11 +66,11 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/source/Energinet.DataHub.MessageHub.Client.SimpleInjector/Energinet.DataHub.MessageHub.Client.SimpleInjector.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.Client.SimpleInjector</PackageId>
-	  <PackageVersion>1.6.1$(VersionSuffix)</PackageVersion>
+	  <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
 	  <Title>Energinet.DataHub.MessageHub.Client.SimpleInjector library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageHub.Client.Tests/.editorconfig
+++ b/source/Energinet.DataHub.MessageHub.Client.Tests/.editorconfig
@@ -1,0 +1,23 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MessageHub.Client.Tests/.editorconfig
+++ b/source/Energinet.DataHub.MessageHub.Client.Tests/.editorconfig
@@ -20,4 +20,5 @@
 # .NET Analyzers              #
 ###############################
 
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
 dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MessageHub.Client.Tests/Energinet.DataHub.MessageHub.Client.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.Tests/Energinet.DataHub.MessageHub.Client.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MessageHub.Client.Tests/Energinet.DataHub.MessageHub.Client.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.Tests/Energinet.DataHub.MessageHub.Client.Tests.csproj
@@ -21,15 +21,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.5" />
+    <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MessageHub.Client.Tests/Energinet.DataHub.MessageHub.Client.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client.Tests/Energinet.DataHub.MessageHub.Client.Tests.csproj
@@ -21,15 +21,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.6" />
+    <PackageReference Include="xunit.categories" Version="2.0.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MessageHub.Client/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MessageHub.Client/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MessageHub.Client Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade.
+
 ## Version 1.0.0
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
@@ -65,10 +65,10 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Model" Version="1.3.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.Client</PackageId>
-    <PackageVersion>1.9.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{E9F64300-834B-4657-850F-BEF4CED5D180}</ProjectGuid>

--- a/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
@@ -65,10 +65,10 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Model" Version="1.3.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MessageHub.Core.Tests/.editorconfig
+++ b/source/Energinet.DataHub.MessageHub.Core.Tests/.editorconfig
@@ -1,0 +1,23 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MessageHub.Core.Tests/.editorconfig
+++ b/source/Energinet.DataHub.MessageHub.Core.Tests/.editorconfig
@@ -20,4 +20,5 @@
 # .NET Analyzers              #
 ###############################
 
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
 dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MessageHub.Core.Tests/Energinet.DataHub.MessageHub.Core.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core.Tests/Energinet.DataHub.MessageHub.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MessageHub.Core.Tests/Energinet.DataHub.MessageHub.Core.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core.Tests/Energinet.DataHub.MessageHub.Core.Tests.csproj
@@ -21,15 +21,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.5" />
+    <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MessageHub.Core.Tests/Energinet.DataHub.MessageHub.Core.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core.Tests/Energinet.DataHub.MessageHub.Core.Tests.csproj
@@ -21,15 +21,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.6" />
+    <PackageReference Include="xunit.categories" Version="2.0.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MessageHub.Core/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MessageHub.Core/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MessageHub.Core Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade.
+
 ## Version 1.0.0
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
@@ -65,10 +65,10 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Model" Version="1.3.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{67C95CC9-95E6-4D05-B14B-2AEF2A961C04}</ProjectGuid>

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.Core</PackageId>
-    <PackageVersion>1.4.1$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.Core library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
@@ -65,10 +65,10 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Model" Version="1.3.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Peek/DataBundleRequestSender.cs
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Peek/DataBundleRequestSender.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.MessageHub.Core.Extensions;
@@ -42,6 +43,7 @@ namespace Energinet.DataHub.MessageHub.Core.Peek
             _peekRequestConfig = peekRequestConfig;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<DataBundleResponseDto?> SendAsync(
             DataBundleRequestDto dataBundleRequestDto,
             DomainOrigin domainOrigin)

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Storage/StorageHandler.cs
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Storage/StorageHandler.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -54,6 +55,7 @@ namespace Energinet.DataHub.MessageHub.Core.Storage
             }
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task AddDataAvailableNotificationIdsToStorageAsync(
             string dataAvailableNotificationReferenceId,
             IEnumerable<Guid> dataAvailableNotificationIds)

--- a/source/Energinet.DataHub.MessageHub.IntegrationTesting/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MessageHub.IntegrationTesting/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MessageHub.IntegrationTesting Release Notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade.
+
 ## Version 1.0.0
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj
+++ b/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.IntegrationTesting</PackageId>
-    <PackageVersion>1.1.2$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.IntegrationTesting library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj
+++ b/source/Energinet.DataHub.MessageHub.IntegrationTesting/source/Energinet.DataHub.MessageHub.IntegrationTesting/Energinet.DataHub.MessageHub.IntegrationTesting.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{34056092-767C-485A-B0A8-9A15147EBB6D}</ProjectGuid>

--- a/source/Energinet.DataHub.MessageHub.Model.Tests/Energinet.DataHub.MessageHub.Model.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model.Tests/Energinet.DataHub.MessageHub.Model.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MessageHub.Model.Tests/Energinet.DataHub.MessageHub.Model.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model.Tests/Energinet.DataHub.MessageHub.Model.Tests.csproj
@@ -21,15 +21,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.5" />
+    <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MessageHub.Model.Tests/Energinet.DataHub.MessageHub.Model.Tests.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model.Tests/Energinet.DataHub.MessageHub.Model.Tests.csproj
@@ -21,15 +21,15 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.6" />
+    <PackageReference Include="xunit.categories" Version="2.0.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MessageHub.Model/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MessageHub.Model/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MessageHub.Model Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade.
+
 ## Version 1.0.0
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
@@ -65,12 +65,12 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.41.1">
+    <PackageReference Include="Google.Protobuf" Version="3.20.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.45.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.Model</PackageId>
-    <PackageVersion>1.3.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.Model library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
@@ -65,12 +65,12 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.20.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.45.0">
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.41.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
+++ b/source/Energinet.DataHub.MessageHub.Model/source/Energinet.DataHub.MessageHub.Model/Energinet.DataHub.MessageHub.Model.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <ProjectGuid>{D2990931-F927-4950-ADC9-9EF6505372EC}</ProjectGuid>

--- a/source/Energinet.DataHub.PostOffice.Application/Energinet.DataHub.PostOffice.Application.csproj
+++ b/source/Energinet.DataHub.PostOffice.Application/Energinet.DataHub.PostOffice.Application.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.PostOffice.Common/Auth/ActorProvider.cs
+++ b/source/Energinet.DataHub.PostOffice.Common/Auth/ActorProvider.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Data;
 using System.Data.SqlClient;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Threading.Tasks;
 using Energinet.DataHub.Core.App.Common.Abstractions.Actor;
@@ -30,6 +31,7 @@ namespace Energinet.DataHub.PostOffice.Common.Auth
             _actorDbConfig = actorDbConfig;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<Actor> GetActorAsync(Guid actorId)
         {
             const string param = "ACTOR_ID";

--- a/source/Energinet.DataHub.PostOffice.Common/Energinet.DataHub.PostOffice.Common.csproj
+++ b/source/Energinet.DataHub.PostOffice.Common/Energinet.DataHub.PostOffice.Common.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.PostOffice.Common/Extensions/ExceptionExtensions.cs
+++ b/source/Energinet.DataHub.PostOffice.Common/Extensions/ExceptionExtensions.cs
@@ -48,6 +48,7 @@ namespace Energinet.DataHub.PostOffice.Common.Extensions
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public static async Task<HttpResponseData> AsHttpResponseDataAsync(this Exception source, HttpRequestData request)
         {
             static async Task<HttpResponseData> CreateHttpResponseData(HttpRequestData request, HttpStatusCode httpStatusCode, ErrorDescriptor error)

--- a/source/Energinet.DataHub.PostOffice.Domain/Energinet.DataHub.PostOffice.Domain.csproj
+++ b/source/Energinet.DataHub.PostOffice.Domain/Energinet.DataHub.PostOffice.Domain.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.PostOffice.EntryPoint.MarketOperator/Energinet.DataHub.PostOffice.EntryPoint.MarketOperator.csproj
+++ b/source/Energinet.DataHub.PostOffice.EntryPoint.MarketOperator/Energinet.DataHub.PostOffice.EntryPoint.MarketOperator.csproj
@@ -15,9 +15,9 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/source/Energinet.DataHub.PostOffice.EntryPoint.Operations/Energinet.DataHub.PostOffice.EntryPoint.Operations.csproj
+++ b/source/Energinet.DataHub.PostOffice.EntryPoint.Operations/Energinet.DataHub.PostOffice.EntryPoint.Operations.csproj
@@ -15,9 +15,9 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <Nullable>enable</Nullable>

--- a/source/Energinet.DataHub.PostOffice.EntryPoint.Operations/HealthCheck/ServiceBusQueueVerifier.cs
+++ b/source/Energinet.DataHub.PostOffice.EntryPoint.Operations/HealthCheck/ServiceBusQueueVerifier.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 
@@ -20,13 +21,16 @@ namespace Energinet.DataHub.PostOffice.EntryPoint.Operations.HealthCheck
 {
     public sealed class ServiceBusQueueVerifier : IServiceBusQueueVerifier
     {
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<bool> VerifyAsync(string connectionString, string name)
         {
             try
             {
                 await using var client = new ServiceBusClient(connectionString);
+
                 await using var receiver = client.CreateReceiver(name);
                 await receiver.PeekMessagesAsync(1).ConfigureAwait(false);
+
                 return true;
             }
 #pragma warning disable CA1031

--- a/source/Energinet.DataHub.PostOffice.EntryPoint.Operations/HealthCheck/SqlDatabaseVerifier.cs
+++ b/source/Energinet.DataHub.PostOffice.EntryPoint.Operations/HealthCheck/SqlDatabaseVerifier.cs
@@ -14,12 +14,14 @@
 
 using System;
 using System.Data.SqlClient;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Energinet.DataHub.PostOffice.EntryPoint.Operations.HealthCheck
 {
     public sealed class SqlDatabaseVerifier : ISqlDatabaseVerifier
     {
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<bool> VerifyAsync(string connectionString)
         {
             try

--- a/source/Energinet.DataHub.PostOffice.EntryPoint.SubDomain/Energinet.DataHub.PostOffice.EntryPoint.SubDomain.csproj
+++ b/source/Energinet.DataHub.PostOffice.EntryPoint.SubDomain/Energinet.DataHub.PostOffice.EntryPoint.SubDomain.csproj
@@ -15,9 +15,9 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <Nullable>enable</Nullable>

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/Common/CosmosExtensions.cs
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/Common/CosmosExtensions.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos.Linq;
@@ -47,6 +48,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure.Common
         }
 
         // This method exists, because we have to put ConfigureAwait(false) on IAsyncEnumerable.
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public static async Task<T> SingleAsync<T>(this IAsyncEnumerable<T> enumerable)
         {
             await using var enumerator = enumerable.ConfigureAwait(false).GetAsyncEnumerator();
@@ -67,6 +69,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure.Common
         }
 
         // This method exists, because we have to put ConfigureAwait(false) on IAsyncEnumerable.
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public static async Task<T?> SingleOrDefaultAsync<T>(this IAsyncEnumerable<T> enumerable)
         {
             await using var enumerator = enumerable.ConfigureAwait(false).GetAsyncEnumerator();

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/Energinet.DataHub.PostOffice.Infrastructure.csproj
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/Energinet.DataHub.PostOffice.Infrastructure.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.PostOffice.Infrastructure/Services/BundleContentRequestService.cs
+++ b/source/Energinet.DataHub.PostOffice.Infrastructure/Services/BundleContentRequestService.cs
@@ -67,7 +67,7 @@ namespace Energinet.DataHub.PostOffice.Infrastructure.Services
             {
                 _logger.LogProcess("Peek", "DomainErrorResponse", _correlationIdProvider.CorrelationId, bundle.Recipient.ToString(), bundle.BundleId.ToString(), bundle.Origin.ToString());
                 _logger.LogError(
-                    "Domain returned an error {0}. Correlation ID: {1}.\nDescription: {2}",
+                    "Domain returned an error {Reason}. Correlation ID: {CorrelationId}.\nDescription: {FailureDescription}",
                     response.ResponseError.Reason,
                     _correlationIdProvider.CorrelationId,
                     response.ResponseError.FailureDescription);

--- a/source/Energinet.DataHub.PostOffice.IntegrationTests/.editorconfig
+++ b/source/Energinet.DataHub.PostOffice.IntegrationTests/.editorconfig
@@ -1,0 +1,23 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.PostOffice.IntegrationTests/.editorconfig
+++ b/source/Energinet.DataHub.PostOffice.IntegrationTests/.editorconfig
@@ -20,4 +20,5 @@
 # .NET Analyzers              #
 ###############################
 
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
 dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.PostOffice.IntegrationTests/Energinet.DataHub.PostOffice.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.PostOffice.IntegrationTests/Energinet.DataHub.PostOffice.IntegrationTests.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.PostOffice.Tests/.editorconfig
+++ b/source/Energinet.DataHub.PostOffice.Tests/.editorconfig
@@ -1,0 +1,23 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.PostOffice.Tests/.editorconfig
+++ b/source/Energinet.DataHub.PostOffice.Tests/.editorconfig
@@ -20,4 +20,5 @@
 # .NET Analyzers              #
 ###############################
 
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
 dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.PostOffice.Tests/Energinet.DataHub.PostOffice.Tests.csproj
+++ b/source/Energinet.DataHub.PostOffice.Tests/Energinet.DataHub.PostOffice.Tests.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.PostOffice.Utilities/Energinet.DataHub.PostOffice.Utilities.csproj
+++ b/source/Energinet.DataHub.PostOffice.Utilities/Energinet.DataHub.PostOffice.Utilities.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.PostOffice.Utilities/LoggerExtensions.cs
+++ b/source/Energinet.DataHub.PostOffice.Utilities/LoggerExtensions.cs
@@ -21,22 +21,22 @@ namespace Energinet.DataHub.PostOffice.Utilities
     {
         public static void LogProcess(this ILogger source, string entryPoint, string correlationId, string gln)
         {
-            source.LogInformation("EntryPoint={0};CorrelationId={1};Gln={2}", entryPoint, correlationId, gln);
+            source.LogInformation("EntryPoint={EntryPoint};CorrelationId={CorrelationId};Gln={Gln}", entryPoint, correlationId, gln);
         }
 
         public static void LogProcess(this ILogger source, string entryPoint, string status, string correlationId, string gln, string bundleId)
         {
-            source.LogInformation("EntryPoint={0};Status={1};CorrelationId={2};Gln={3};BundleId={4}", entryPoint, status, correlationId, gln, bundleId);
+            source.LogInformation("EntryPoint={EntryPoint};Status={Status};CorrelationId={CorrelationId};Gln={Gln};BundleId={BundleId}", entryPoint, status, correlationId, gln, bundleId);
         }
 
         public static void LogProcess(this ILogger source, string entryPoint, string status, string correlationId, string gln, string bundleId, string domain)
         {
-            source.LogInformation("EntryPoint={0};Status={1};CorrelationId={2};Gln={3};BundleId={4};Domain={5}", entryPoint, status, correlationId, gln, bundleId, domain);
+            source.LogInformation("EntryPoint={EntryPoint};Status={Status};CorrelationId={CorrelationId};Gln={Gln};BundleId={BundleId};Domain={Domain}", entryPoint, status, correlationId, gln, bundleId, domain);
         }
 
         public static void LogProcess(this ILogger source, string entryPoint, string status, string correlationId, string gln, string bundleId, IEnumerable<string> dataAvailables)
         {
-            source.LogInformation("EntryPoint={0};Status={1};CorrelationId={2};Gln={3};BundleId={4};DataAvailables={5}", entryPoint, status, correlationId, gln, bundleId, string.Join(",", dataAvailables));
+            source.LogInformation("EntryPoint={EntryPoint};Status={Status};CorrelationId={CorrelationId};Gln={Gln};BundleId={BundleId};DataAvailables={DataAvailables}", entryPoint, status, correlationId, gln, bundleId, string.Join(",", dataAvailables));
         }
     }
 }

--- a/source/Microsoft.Azure.Functions.Isolated.TestDoubles/Microsoft.Azure.Functions.Isolated.TestDoubles.csproj
+++ b/source/Microsoft.Azure.Functions.Isolated.TestDoubles/Microsoft.Azure.Functions.Isolated.TestDoubles.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Upgrade Post Office to .NET 6 and Functions v4.

Important:
* Focus is on upgrading to .NET 6 and functions v4. Only NuGet packages directly impacted by this (meaning Analyzers) has been updated.
* NuGet packages build within the domain has also been updated to .NET 6 and all version numbers bumped to the next major version to signal the "breaking change". It means that any domain that want to use these packages in the future, must update their domain to .NET 6 (which is what we want anyway).

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/258