### PR TITLE
feat: OperationTimestamp is now instant

### DIFF
--- a/source/Energinet.DataHub.MessageHub.Client.Tests/ServiceBusMessageExtensionsTests.cs
+++ b/source/Energinet.DataHub.MessageHub.Client.Tests/ServiceBusMessageExtensionsTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.MessageHub.Client.Extensions;
+using Energinet.DataHub.MessageHub.Model.IntegrationEvents;
+using NodaTime.Text;
+using Xunit;
+
+namespace Energinet.DataHub.MessageHub.Client.Tests;
+
+public class ServiceBusMessageExtensionsTests
+{
+    [Fact]
+    public void AddDataAvailableIntegrationEvents_WithValidData_CanBeReadBack()
+    {
+        // Arrange
+        var target = new ServiceBusMessage();
+        var correlationId = Guid.NewGuid().ToString();
+
+        // Act
+        target.AddDataAvailableIntegrationEvents(correlationId);
+
+        // Assert
+        var properties = target.ApplicationProperties;
+
+        AssertValidTimestamp(properties);
+        Assert.Equal(correlationId, properties["OperationCorrelationId"]);
+        Assert.Equal(1, properties["MessageVersion"]);
+        Assert.Equal(nameof(IntegrationEventsMessageType.DataAvailable), properties["MessageType"]);
+        Assert.True(Guid.TryParse((string)properties["EventIdentification"], out _));
+    }
+
+    [Fact]
+    public void AddDataBundleResponseIntegrationEvents_WithValidData_CanBeReadBack()
+    {
+        // Arrange
+        var target = new ServiceBusMessage();
+        var correlationId = Guid.NewGuid().ToString();
+
+        // Act
+        target.AddDataBundleResponseIntegrationEvents(correlationId);
+
+        // Assert
+        var properties = target.ApplicationProperties;
+
+        AssertValidTimestamp(properties);
+        Assert.Equal(correlationId, properties["OperationCorrelationId"]);
+        Assert.Equal(1, properties["MessageVersion"]);
+        Assert.Equal(nameof(IntegrationEventsMessageType.DataBundleResponse), properties["MessageType"]);
+        Assert.True(Guid.TryParse((string)properties["EventIdentification"], out _));
+    }
+
+    private static void AssertValidTimestamp(IDictionary<string, object> properties)
+    {
+        var timestamp = (string)properties["OperationTimestamp"];
+        var instant = InstantPattern.ExtendedIso.Parse(timestamp);
+
+        Assert.True(instant.Success);
+        Assert.Equal(instant.Value.ToString(), timestamp);
+    }
+}

--- a/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
+++ b/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Energinet.DataHub.MessageHub.Client.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.Client</PackageId>
-    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.1$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -69,6 +69,7 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Model" Version="3.0.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="NodaTime" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Extensions/ServiceBusMessageExtensions.cs
+++ b/source/Energinet.DataHub.MessageHub.Client/source/Energinet.DataHub.MessageHub.Client/Extensions/ServiceBusMessageExtensions.cs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 using System;
+using System.Globalization;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.MessageHub.Model.IntegrationEvents;
+using NodaTime;
+using NodaTime.Text;
 
 namespace Energinet.DataHub.MessageHub.Client.Extensions
 {
@@ -42,7 +45,7 @@ namespace Energinet.DataHub.MessageHub.Client.Extensions
             IntegrationEventsMessageType messageType,
             string eventIdentification)
         {
-            serviceBusMessage.ApplicationProperties.Add("OperationTimestamp", DateTimeOffset.UtcNow);
+            serviceBusMessage.ApplicationProperties.Add("OperationTimestamp", SystemClock.Instance.GetCurrentInstant().ToString(null, CultureInfo.InvariantCulture));
             serviceBusMessage.ApplicationProperties.Add("OperationCorrelationId", operationCorrelationId);
             serviceBusMessage.ApplicationProperties.Add("MessageVersion", 1);
             serviceBusMessage.ApplicationProperties.Add("MessageType", messageType.ToString());

--- a/source/Energinet.DataHub.MessageHub.Core.Tests/ServiceBusMessageExtensionsTests.cs
+++ b/source/Energinet.DataHub.MessageHub.Core.Tests/ServiceBusMessageExtensionsTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Messaging.ServiceBus;
+using Energinet.DataHub.MessageHub.Core.Extensions;
+using Energinet.DataHub.MessageHub.Model.IntegrationEvents;
+using NodaTime.Text;
+using Xunit;
+
+namespace Energinet.DataHub.MessageHub.Core.Tests;
+
+public class ServiceBusMessageExtensionsTests
+{
+    [Fact]
+    public void AddRequestDataBundleIntegrationEvents_WithValidData_CanBeReadBack()
+    {
+        // Arrange
+        var target = new ServiceBusMessage();
+        var correlationId = Guid.NewGuid().ToString();
+
+        // Act
+        target.AddRequestDataBundleIntegrationEvents(correlationId);
+
+        // Assert
+        var properties = target.ApplicationProperties;
+
+        AssertValidTimestamp(properties);
+        Assert.Equal(correlationId, properties["OperationCorrelationId"]);
+        Assert.Equal(1, properties["MessageVersion"]);
+        Assert.Equal(nameof(IntegrationEventsMessageType.RequestDataBundle), properties["MessageType"]);
+        Assert.True(Guid.TryParse((string)properties["EventIdentification"], out _));
+    }
+
+    [Fact]
+    public void AddDequeueIntegrationEvents_WithValidData_CanBeReadBack()
+    {
+        // Arrange
+        var target = new ServiceBusMessage();
+        var correlationId = Guid.NewGuid().ToString();
+
+        // Act
+        target.AddDequeueIntegrationEvents(correlationId);
+
+        // Assert
+        var properties = target.ApplicationProperties;
+
+        AssertValidTimestamp(properties);
+        Assert.Equal(correlationId, properties["OperationCorrelationId"]);
+        Assert.Equal(1, properties["MessageVersion"]);
+        Assert.Equal(nameof(IntegrationEventsMessageType.Dequeue), properties["MessageType"]);
+        Assert.True(Guid.TryParse((string)properties["EventIdentification"], out _));
+    }
+
+    private static void AssertValidTimestamp(IDictionary<string, object> properties)
+    {
+        var timestamp = (string)properties["OperationTimestamp"];
+        var instant = InstantPattern.ExtendedIso.Parse(timestamp);
+
+        Assert.True(instant.Success);
+        Assert.Equal(instant.Value.ToString(), timestamp);
+    }
+}

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Energinet.DataHub.MessageHub.Core.csproj
@@ -28,7 +28,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MessageHub.Core</PackageId>
-    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.1$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MessageHub.Core library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -69,6 +69,7 @@ https://github.com/Energinet-DataHub/geh-post-office/blob/master/source/Energine
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Model" Version="3.0.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="NodaTime" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Extensions/ServiceBusMessageExtensions.cs
+++ b/source/Energinet.DataHub.MessageHub.Core/source/Energinet.DataHub.MessageHub.Core/Extensions/ServiceBusMessageExtensions.cs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 using System;
+using System.Globalization;
 using Azure.Messaging.ServiceBus;
 using Energinet.DataHub.MessageHub.Model.IntegrationEvents;
+using NodaTime;
 
 namespace Energinet.DataHub.MessageHub.Core.Extensions
 {
@@ -44,7 +46,7 @@ namespace Energinet.DataHub.MessageHub.Core.Extensions
         {
             ArgumentNullException.ThrowIfNull(serviceBusMessage, nameof(serviceBusMessage));
 
-            serviceBusMessage.ApplicationProperties.Add("OperationTimestamp", DateTimeOffset.UtcNow);
+            serviceBusMessage.ApplicationProperties.Add("OperationTimestamp", SystemClock.Instance.GetCurrentInstant().ToString(null, CultureInfo.InvariantCulture));
             serviceBusMessage.ApplicationProperties.Add("OperationCorrelationId", operationCorrelationId);
             serviceBusMessage.ApplicationProperties.Add("MessageVersion", 1);
             serviceBusMessage.ApplicationProperties.Add("MessageType", messageType.ToString());


### PR DESCRIPTION
Description
-----------------
Upon deserializing the ServiceBusMessage.ApplicationProperties[OperationTimestamp]`  to an `Instant` we encountered a format error. 

This PR will change the data type for the `ServiceBusMessage.ApplicationProperties[OperationTimestamp]` from `DateTimeOffset.UtcNow` to the stringvalue of `SystemClock.Instance.GetCurrentInstant()` with invariant cultureinfo. To ensure the value can be parsed to an `Instant` again.