### PR TITLE
adding missing RuleSet for DataAvailableNotificationCleanUpCommand

### DIFF
--- a/source/Energinet.DataHub.PostOffice.Application/Validation/DataAvailableNotificationCleanUpCommandRuleSet.cs
+++ b/source/Energinet.DataHub.PostOffice.Application/Validation/DataAvailableNotificationCleanUpCommandRuleSet.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.PostOffice.Application.Commands;
+using Energinet.DataHub.PostOffice.Application.Validation.Rules;
+using FluentValidation;
+
+namespace Energinet.DataHub.PostOffice.Application.Validation
+{
+    public sealed class DataAvailableNotificationCleanUpCommandRuleSet : AbstractValidator<DataAvailableNotificationCleanUpCommand>
+    {
+    }
+}

--- a/source/Energinet.DataHub.PostOffice.Common/ApplicationServiceRegistration.cs
+++ b/source/Energinet.DataHub.PostOffice.Common/ApplicationServiceRegistration.cs
@@ -35,6 +35,7 @@ namespace Energinet.DataHub.PostOffice.Common
             container.Register<IValidator<DequeueCommand>, DequeueCommandRuleSet>(Lifestyle.Scoped);
 
             container.Register<IValidator<InsertDataAvailableNotificationsCommand>, InsertDataAvailableNotificationsCommandRuleSet>(Lifestyle.Scoped);
+            container.Register<IValidator<DataAvailableNotificationCleanUpCommand>, DataAvailableNotificationCleanUpCommandRuleSet>(Lifestyle.Scoped);
             container.Register<IValidator<GetMaximumSequenceNumberCommand>, GetMaximumSequenceNumberCommandRuleSet>(Lifestyle.Scoped);
             container.Register<IValidator<UpdateMaximumSequenceNumberCommand>, UpdateMaximumSequenceNumberCommandRuleSet>(Lifestyle.Scoped);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-post-office) before we can accept your contribution. --->

## Description

adding missing RuleSet for DataAvailableNotificationCleanUpCommand
## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000